### PR TITLE
Fix incorrect OpenAPI entries (#8)

### DIFF
--- a/Model/schema/ocm-openapi-spec.yaml
+++ b/Model/schema/ocm-openapi-spec.yaml
@@ -439,6 +439,7 @@ components:
   schemas:
     POI:
       title: POI
+      x-go-name: ChargePoint
       type: object
       description: |-
         A POI (Point of Interest), also referred to as a `Site` or `ChargePoint`, is the top-level set of information regarding a geographic site with one or more electric vehicle charging equipment present. The term `ChargePointID` is used to reference the unique ID for each POI, as called OCM ID. This reference appears in various UI elements in the format `OCM-12345` to distinguish the ID number as being a reference for a specific POI/site.

--- a/Model/schema/ocm-openapi-spec.yaml
+++ b/Model/schema/ocm-openapi-spec.yaml
@@ -51,7 +51,7 @@ paths:
           name: countryid
           description: Exact match on a given numeric country id (comma separated list)
         - schema:
-            type: integer
+            type: number
           in: query
           name: latitude
           description: Latitude for distance calculation and filtering
@@ -572,7 +572,7 @@ components:
           ID: 148527
           UUID: 4C524AA1-3413-4D56-804C-480304FEB0FB
           UserComments:
-            - ID: string
+            - ID: 0
               ChargePointID: 0
               CommentTypeID: 0
               CommentType: {}
@@ -589,8 +589,8 @@ components:
               CheckinStatusType: {}
               '': string
           MediaItems:
-            - ID: string
-              ChargePointID: string
+            - ID: int
+              ChargePointID: int
               ItemURL: string
               ItemThumbnailURL: string
               Comment: string
@@ -1053,7 +1053,7 @@ components:
       description: A user comment or check-in for a specific charging point (POI/Site)
       properties:
         ID:
-          type: string
+          type: integer
         ChargePointID:
           type: integer
         CommentTypeID:
@@ -1080,9 +1080,9 @@ components:
       description: A user submitted media item related to a specific charge point or site. Currently always an image.
       properties:
         ID:
-          type: string
+          type: integer
         ChargePointID:
-          type: string
+          type: integer
         ItemURL:
           type: string
         ItemThumbnailURL:
@@ -1751,7 +1751,7 @@ components:
               - ID: 148527
                 UUID: 4C524AA1-3413-4D56-804C-480304FEB0FB
                 UserComments:
-                  - ID: string
+                  - ID: 0
                     ChargePointID: 0
                     CommentTypeID: 0
                     CommentType:
@@ -1773,8 +1773,8 @@ components:
                       IsAutomatedCheckin: true
                       IsPositive: true
                 MediaItems:
-                  - ID: string
-                    ChargePointID: string
+                  - ID: 0
+                    ChargePointID: 0
                     ItemURL: string
                     ItemThumbnailURL: string
                     Comment: string


### PR DESCRIPTION
This PR updates the OCM OpenAPI yaml per the discussion in #8.

One commit fixes the incorrect types.  

The other commit adds an annotation that was needed for [Golang bindings](https://github.com/neomantra/go-openchargemap).

There remains whether `boundingbox` query parameter is an `array` or `string`.  I have not included that one-line change in this commit series.

🔌 ❤️ 